### PR TITLE
fix dashboard don't load

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,18 @@
-FROM       node:10.11-alpine
+FROM       node:12-alpine
 LABEL      maintainer="Sander Bel <sander@intelliops.be>"
-
-ARG        CRONICLE_VERSION='0.8.28'
 
 # Docker defaults
 ENV        CRONICLE_base_app_url 'http://localhost:3012'
 ENV        CRONICLE_WebServer__http_port 3012
 ENV        CRONICLE_WebServer__https_port 443
-ENV        CRONICLE_web_socket_use_hostnames 1
-ENV        CRONICLE_server_comm_use_hostnames 1
-ENV        CRONICLE_web_direct_connect 0
-ENV        CRONICLE_socket_io_transports '["polling", "websocket"]'
 
-RUN        apk add --no-cache git curl wget perl bash perl-pathtools tar \
-             procps tini
-
+# Runtime user
 RUN        adduser cronicle -D -h /opt/cronicle
 
-USER       cronicle
+RUN        apk add --no-cache git curl wget perl bash perl-pathtools tar procps tini
+RUN        curl -s https://raw.githubusercontent.com/jhuckaby/Cronicle/master/bin/install.js | node
 
 WORKDIR    /opt/cronicle/
-
-RUN        mkdir -p data logs plugins
-
-RUN        curl -L "https://github.com/jhuckaby/Cronicle/archive/v${CRONICLE_VERSION}.tar.gz" | tar zxvf - --strip-components 1 && \
-           npm install && \
-           node bin/build.js dist
-
 ADD        entrypoint.sh /entrypoint.sh
 
 EXPOSE     3012
@@ -35,5 +21,4 @@ EXPOSE     3012
 VOLUME     ["/opt/cronicle/data", "/opt/cronicle/logs", "/opt/cronicle/plugins"]
 
 ENTRYPOINT ["/sbin/tini", "--"]
-
 CMD        ["sh", "/entrypoint.sh"]

--- a/Dockerfile.letsencrypt
+++ b/Dockerfile.letsencrypt
@@ -1,4 +1,4 @@
-FROM       intelliops/cronicle:0.8.28
+FROM       intelliops/cronicle:latest
 LABEL      maintainer="Sander Bel <sander@intelliops.be>"
 
 USER       root

--- a/Dockerfile.s3
+++ b/Dockerfile.s3
@@ -1,4 +1,4 @@
-FROM       intelliops/cronicle:0.8.28
+FROM       intelliops/cronicle:latest
 LABEL      maintainer="Sander Bel <sander@intelliops.be>"
 
 USER       root

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+**DEPRECATED**
+
+**Please use https://github.com/bluet/docker-cronicle-docker instead.**
+
 # docker-cronicle
 [![Build status](https://img.shields.io/docker/build/intelliops/cronicle.svg)](https://hub.docker.com/r/intelliops/cronicle) [![Build status](https://img.shields.io/travis/belsander/docker-cronicle/master.svg)](https://travis-ci.org/belsander/docker-cronicle)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,5 +35,6 @@ then
   touch $DATA_DIR/.setup_done
 fi
 
-# Run cronicle
-/usr/local/bin/node "$LIB_DIR/main.js"
+# Run cronicle with unprivileged user
+chown -R cronicle:cronicle data/ logs/
+exec su cronicle -c "/opt/cronicle/bin/control.sh start"


### PR DESCRIPTION
fixed: use node:12-alpine to fix timer issue
fixed: remove problematic ENV (websocket related) to fix dashboard loading issue
fixed: install process for new version of cronicle
fixed: drop privilege too early causes installation failed

fixed https://github.com/jhuckaby/Cronicle/issues/239
fixed https://github.com/belsander/docker-cronicle/issues/17