### PR TITLE
Remove socket_io_transports option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ ENV        CRONICLE_WebServer__https_port 443
 ENV        CRONICLE_web_socket_use_hostnames 1
 ENV        CRONICLE_server_comm_use_hostnames 1
 ENV        CRONICLE_web_direct_connect 0
-ENV        CRONICLE_socket_io_transports '["polling", "websocket"]'
 
 RUN        apk add --no-cache git curl wget perl bash perl-pathtools tar \
              procps tini


### PR DESCRIPTION
This option cannot be set with the environment variable syntax being used here. For most scenarios the default should be fine. AFAIK using polling is not required in a Docker environment.